### PR TITLE
[YGBWSLA-823] Remove automatic scroll on the AF steps and move Location filter

### DIFF
--- a/openy_af4_vue_app/src/App.vue
+++ b/openy_af4_vue_app/src/App.vue
@@ -613,8 +613,6 @@ export default {
     },
     updateUrlString() {
       this.updateUrl()
-      // Scroll to top.
-      window.scrollTo({ top: 0, behavior: 'smooth' })
     },
     step(val, oldVal) {
       // Check if we returned to previously completed step - using browser back button - then we

--- a/openy_af4_vue_app/src/App.vue
+++ b/openy_af4_vue_app/src/App.vue
@@ -382,6 +382,7 @@ export default {
       canLoadData: true,
       // Search parameters of the last request casted to string primitive.
       lastRequestParamsString: '',
+      initialLoad: true,
       // Indicates if we are working with Daxko backend.
       daxko: false,
       daxkoPages: [],
@@ -630,7 +631,12 @@ export default {
 
       this.canLoadData = true
 
-      // Scroll to view.
+      // Scroll to top on step change, except on initial load if step is 'results'
+      if (this.initialLoad && val === 'results') {
+        this.initialLoad = false
+        return
+      }
+
       document.getElementById('activity-finder-app').scrollIntoView(true)
     },
     selectedPage() {

--- a/openy_af4_vue_app/src/components/filters/Filters.vue
+++ b/openy_af4_vue_app/src/components/filters/Filters.vue
@@ -8,6 +8,22 @@
     </div>
     <div class="filters">
       <Fieldset
+        :label="'Locations' | t"
+        :collapse-id="id + '-toggle-locations'"
+        :collapsed="fieldsetCollapseState('locations')"
+        :counter="locationFiltersCount"
+        :hide-counter="true"
+      >
+        <LocationsFilter
+          :id="id + '-locations-filter'"
+          v-model="selectedLocations"
+          :locations="locations"
+          :facets="data.facets.locations"
+          :exclude-by-location="excludeByLocation"
+        />
+      </Fieldset>
+
+      <Fieldset
         :label="'Schedules' | t"
         :collapse-id="id + '-toggle-schedules'"
         :collapsed="fieldsetCollapseState('schedule')"
@@ -67,22 +83,6 @@
           :multiple="!daxko"
           :limit-by-category="limitByCategory"
           :exclude-by-category="excludeByCategory"
-        />
-      </Fieldset>
-
-      <Fieldset
-        :label="'Locations' | t"
-        :collapse-id="id + '-toggle-locations'"
-        :collapsed="fieldsetCollapseState('locations')"
-        :counter="locationFiltersCount"
-        :hide-counter="true"
-      >
-        <LocationsFilter
-          :id="id + '-locations-filter'"
-          v-model="selectedLocations"
-          :locations="locations"
-          :facets="data.facets.locations"
-          :exclude-by-location="excludeByLocation"
         />
       </Fieldset>
     </div>


### PR DESCRIPTION
Task: https://fivejars.atlassian.net/browse/YGBWSLA-823 (1,2,3)
The client requested several adjustments for the AF:
- Remove automatic scroll after the selecting filters
- Remove automatic scroll on the AF steps
- Location (branch) filter should be displayed on top as a first option to filter.

Steps for review:

- [ ] Go to /ymca-activity-finder
- [ ] Check filtes and go to the next/previous steps
- [ ] All these actions should be without autoscrolling
- [ ] Check on the results page. The Locations filter should be at the top first
- [ ] PROFIT